### PR TITLE
Provide deactivate method

### DIFF
--- a/dstc.py
+++ b/dstc.py
@@ -78,6 +78,20 @@ def activate():
     active = True
     return True
 
+
+def deactivate():
+    """Change active to False.
+
+    This allows a user to deactivate DSTC and register/deregister client/server
+    functions.
+
+    .. warning::No expections, no promises that changes will be effected.
+    """
+    global active
+    active = False 
+    return True
+
+
 def process_events(timeout):
     global active
     if not active:


### PR DESCRIPTION
Set global active to false to allow registration of new client and server functions after having processed dstc events for some period of time.