### PR TITLE
Fixed deprecated calls.

### DIFF
--- a/dstc.py
+++ b/dstc.py
@@ -96,8 +96,8 @@ def process_pending_events():
         print("Please call activate() before processing events")
         return False
 
-    dstc_swig.dstc_process_pending_events()
-    return True  
+    dstc_swig.dstc_process_events(0)
+    return True
 
 def remote_function_available(lambda_func):
     global active

--- a/dstc_swig.i
+++ b/dstc_swig.i
@@ -21,8 +21,8 @@
 
     extern uint8_t dstc_remote_function_available(void* func_ptr);
 
-    extern void swig_dstc_process(uint64_t callback_ref, // Not used.
-                                  unsigned int node_id,
+    extern void swig_dstc_process(dstc_callback_t callback_ref, // Not used.
+                                  rmc_node_id_t node_id,
                                   unsigned char* func_name,
                                   unsigned char* payload,
                                   unsigned short payload_len);
@@ -44,9 +44,10 @@
 
 static PyObject *cb_ptr = NULL;
 
-void swig_dstc_process(unsigned long callback_ref, // Not used.
-                       unsigned int node_id,
-                       unsigned char *func_name,
+
+void swig_dstc_process(dstc_callback_t callback_ref, // Not used.
+                       rmc_node_id_t node_id,
+                       unsigned char* func_name,
                        unsigned char* payload,
                        unsigned short payload_len)
 {
@@ -117,7 +118,6 @@ int swig_dstc_queue_callback(unsigned long addr,
 extern int dstc_setup(void);
 typedef long int usec_timestamp_t;
 extern int dstc_process_events(int timeout);
-extern int dstc_process_pending_events(void);
 extern int dstc_queue_func(struct dstc_context*, char* name, unsigned char* arg_buf, unsigned int arg_sz);
 extern unsigned char dstc_remote_function_available_by_name(char* func_name);
 extern int dstc_queue_callback(struct dstc_context*,

--- a/examples/callback_client.py
+++ b/examples/callback_client.py
@@ -4,8 +4,12 @@
 #
 import dstc
 
+do_exit = False
+
 def double_value_callback(doubled_value):
+    global do_exit
     print("Callback-delivered value: {}".format(doubled_value))
+    do_exit = True
 
 if __name__ == "__main__":
     # Setup a client call to the server that will double the value for us.
@@ -29,4 +33,6 @@ if __name__ == "__main__":
     # function is to invoke in order to deliver the result.
     #
     client_func(21, (double_value_callback, "i"))
-    dstc.process_events(100000)
+
+    while not do_exit:
+        dstc.process_events(-1)

--- a/examples/callback_server.py
+++ b/examples/callback_server.py
@@ -5,7 +5,9 @@
 import dstc
 from dstc import current_milli_time
 
+do_exit = False
 def double_value_and_invoke_callback(func_name, value, callback):
+    global do_exit
     print("Will double value: {}".format(value))
     # Invoke the callback in order to deliver the result.
     # The parameter signature ("i") specifies that an integer
@@ -14,6 +16,7 @@ def double_value_and_invoke_callback(func_name, value, callback):
     # the remote client (such as callback_client.py) side invoking
     # this callback.
     callback("i", value * 2)
+    do_exit = True
 
 # PythonBinaryOp class is defined and derived from C++ class BinaryOp
 
@@ -22,9 +25,13 @@ if __name__ == "__main__":
                                   double_value_and_invoke_callback,
                                   "i&")
     dstc.activate()
-    
+
     stop_ts = current_milli_time() + 400
     while (current_milli_time() < stop_ts):
             dstc.process_events(stop_ts - current_milli_time())
 
-    dstc.process_pending_events()
+    while not do_exit:
+        dstc.process_events(-1)
+
+    # Make sure we get the last packets out
+    dstc.process_events(500)

--- a/examples/complex_arg_client.py
+++ b/examples/complex_arg_client.py
@@ -12,4 +12,4 @@ if __name__ == "__main__":
         dstc.process_events(100000)
 
     client_func("32 byte string", b"Dynamic string", [11,22,33])
-    dstc.process_events(10000)
+    dstc.process_events(500)

--- a/examples/complex_arg_server.py
+++ b/examples/complex_arg_server.py
@@ -2,24 +2,26 @@
 # Test python client to exercise
 import dstc
 from dstc import current_milli_time
+do_exit = False
 
 def complex_arg(func_name, name, dynamic, age_array ):
+    global do_exit
     print("Function name: {}".format(func_name))
     print("Name: {}".format(name))
     print("Dynamic: {} / {}".format(dynamic, len(dynamic)))
     print("Age array: {}".format(age_array))
+    do_exit = True
 
-# PythonBinaryOp class is defined and derived from C++ class BinaryOp
 
 if __name__ == "__main__":
     dstc.register_server_function("complex_arg",
                                   complex_arg,
                                   "32s#3i")
     dstc.activate()
-    
+
     stop_ts = current_milli_time() + 400
     while (current_milli_time() < stop_ts):
             dstc.process_events(stop_ts - current_milli_time())
 
-    dstc.process_pending_events()
-
+    while not do_exit:
+        dstc.process_events(-1)

--- a/examples/dynamic_data_client.py
+++ b/examples/dynamic_data_client.py
@@ -12,4 +12,5 @@ if __name__ == "__main__":
         dstc.process_events(100000)
 
     client_func(b"Hello world\x00", [1,2,3,4])
-    dstc.process_events(10000)
+
+    dstc.process_events(500)

--- a/examples/dynamic_data_server.py
+++ b/examples/dynamic_data_server.py
@@ -3,11 +3,15 @@
 import dstc
 from dstc import current_milli_time
 
+do_exit = False
+
 def do_dynamic_data(func, dyndata, int_list):
+    global do_exit
     print("Got server call {}".format(func))
     print("  Dyndata: {}".format(dyndata))
     print("  Dyndata len: {}".format(len(dyndata)))
     print("  Intlist: {}".format(int_list))
+    do_exit = True
 
 # PythonBinaryOp class is defined and derived from C++ class BinaryOp
 if __name__ == "__main__":
@@ -20,4 +24,5 @@ if __name__ == "__main__":
     while (current_milli_time() < stop_ts):
             dstc.process_events(stop_ts - current_milli_time())
 
-    dstc.process_pending_events()
+    while not do_exit:
+        dstc.process_events(-1)

--- a/examples/print_name_and_age_server.py
+++ b/examples/print_name_and_age_server.py
@@ -5,10 +5,12 @@
 import dstc
 from dstc import current_milli_time
 
+do_exit = False
 def do_print_name_and_age(func_name, name, age):
+    global do_exit
     print("Name: {}".format(name))
     print("Age: {}".format(age))
-
+    do_exit = True
 
 if __name__ == "__main__":
     dstc.register_server_function("print_name_and_age",
@@ -21,4 +23,5 @@ if __name__ == "__main__":
     while (current_milli_time() < stop_ts):
             dstc.process_events(stop_ts - current_milli_time())
 
-    dstc.process_pending_events()
+    while not do_exit:
+        dstc.process_events(-1)


### PR DESCRIPTION
All deprecated calls fixed.
Cleaned up examples exit management.
Fixed warning about incompatible pointers for swig_dstc_process.